### PR TITLE
release workflow with binaries now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,13 +157,30 @@ jobs:
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
 
+      - name: Install kernel headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y linux-headers-$(uname -r) build-essential
+
+      - name: Build release binaries
+        run: |
+          make release
+          echo "Build complete. Creating tarball..."
+          cd build
+          tar -czf ../elf_det-${{ steps.new_version.outputs.version }}-amd64.tar.gz *.ko proc_elf_ctrl test_multithread
+          cd ..
+          ls -lh elf_det-*.tar.gz
+
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.new_version.outputs.tag }}
-          release_name: Release ${{ steps.new_version.outputs.tag }}
+          name: Release ${{ steps.new_version.outputs.tag }}
           body_path: /tmp/release_notes.md
           draft: false
           prerelease: false
+          files: |
+            elf_det-${{ steps.new_version.outputs.version }}-amd64.tar.gz
+            build/elf_det.ko
+            build/proc_elf_ctrl
+            build/test_multithread

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ SRC_DIR := src
 # Build directory for user program
 BUILD_DIR := build
 
-.PHONY: all clean module user install uninstall test help unit check format checkpatch sparse cppcheck build-multithread run-multithread
+.PHONY: all clean module user install uninstall test help unit check format checkpatch sparse cppcheck build-multithread run-multithread release
 
 # Default target
 all: module user
@@ -97,6 +97,25 @@ clean:
 	rm -f $(SRC_DIR)/Module.symvers $(SRC_DIR)/modules.order
 	rm -rf $(SRC_DIR)/.tmp_versions
 	@echo "Clean complete!"
+
+# Build release binaries (for distribution)
+release: clean
+	@echo "Building release binaries for amd64..."
+	@mkdir -p $(BUILD_DIR)
+	@# Build kernel module
+	$(MAKE) module
+	@# Build user programs
+	$(MAKE) user
+	$(MAKE) build-multithread
+	@# Strip binaries to reduce size
+	strip $(BUILD_DIR)/$(USER_PROG)
+	strip $(BUILD_DIR)/test_multithread
+	@echo ""
+	@echo "Release binaries built successfully!"
+	@echo "Artifacts:"
+	@ls -lh $(BUILD_DIR)/*.ko $(BUILD_DIR)/$(USER_PROG) $(BUILD_DIR)/test_multithread 2>/dev/null
+	@echo ""
+	@echo "Ready for distribution in: $(BUILD_DIR)/"
 
 # Static Analysis and Code Quality Checks
 
@@ -193,6 +212,7 @@ help:
 	@echo "  make module            - Build kernel module only"
 	@echo "  make user              - Build user program only"
 	@echo "  make build-multithread - Build multi-threaded test program"
+	@echo "  make release           - Build all binaries for release (clean build + stripped)"
 	@echo ""
 	@echo "Run Targets:"
 	@echo "  make install           - Install kernel module (requires root)"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -46,8 +46,26 @@ You can manually trigger a release from the GitHub Actions tab:
 1. **Version Calculation**: The workflow reads the latest git tag and calculates the new version based on the bump type
 2. **Changelog Update**: Adds an entry to the README.md changelog section
 3. **Git Tag Creation**: Creates an annotated git tag (e.g., `v1.4.0`)
-4. **GitHub Release**: Creates a release on GitHub with auto-generated release notes
-5. **Version Commit**: Pushes the updated README.md back to the repository
+4. **Binary Build**: Builds release binaries for amd64 architecture:
+   - `elf_det.ko` - Kernel module
+   - `proc_elf_ctrl` - User-space control program
+   - `test_multithread` - Multi-threaded test program
+   - `elf_det-{version}-amd64.tar.gz` - All binaries packaged together
+5. **GitHub Release**: Creates a release on GitHub with auto-generated release notes and binary artifacts
+6. **Version Commit**: Pushes the updated README.md back to the repository
+
+## Release Artifacts
+
+Each release includes pre-built binaries for amd64/x86_64 architecture:
+
+- **Individual files**:
+  - `elf_det.ko` - The kernel module (load with `insmod`)
+  - `proc_elf_ctrl` - The control program for querying process information
+  - `test_multithread` - Multi-threaded test application
+
+- **Tarball**: `elf_det-{version}-amd64.tar.gz` containing all binaries
+
+**Note**: The kernel module is compiled against the Ubuntu 24.04 kernel. You may need to rebuild from source for other kernel versions.
 
 ## Version Numbering
 
@@ -91,6 +109,29 @@ git describe --tags --abbrev=0
 # Or check the README.md changelog
 grep "### Version" README.md | head -n1
 ```
+
+## Building Release Binaries Locally
+
+To build the same binaries that will be included in a release:
+
+```bash
+# Clean and build all release binaries
+make release
+
+# Binaries will be in build/ directory:
+# - build/elf_det.ko
+# - build/proc_elf_ctrl
+# - build/test_multithread
+
+# Create a tarball (optional)
+cd build
+tar -czf elf_det-dev-amd64.tar.gz *.ko proc_elf_ctrl test_multithread
+```
+
+The `make release` target:
+- Performs a clean build
+- Strips debugging symbols from user-space programs (smaller file size)
+- Builds all components (module + user programs)
 
 ## Example Workflows
 


### PR DESCRIPTION
This pull request adds automated building and packaging of release binaries to the project’s release workflow. It introduces a `make release` target that performs a clean build of all components, strips binaries for smaller size, and packages them for distribution. The GitHub Actions release workflow is updated to build these binaries and attach them as artifacts to each release. Documentation is also updated to describe the new release artifacts and how to build them locally.