### PR TITLE
release notes fixed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,21 +131,21 @@ jobs:
           
           # Create release notes
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # Use PR body for release notes
+            # Use PR metadata from event payload to avoid shell parsing issues
+            PR_TITLE=$(jq -r '.pull_request.title // ""' "$GITHUB_EVENT_PATH")
+            PR_BODY=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
+
             {
-              echo "## ${{ github.event.pull_request.title }}"
-              echo ""
-              echo "${{ github.event.pull_request.body }}"
-              echo ""
-              echo "---"
-              echo "**Version**: $VERSION | **Type**: $BUMP_TYPE"
+              printf '## %s\n\n' "$PR_TITLE"
+              printf '%s\n' "$PR_BODY"
+              printf '\n---\n'
+              printf '**Version**: %s | **Type**: %s\n' "$VERSION" "$BUMP_TYPE"
             } > /tmp/release_notes.md
           else
             # Manual workflow dispatch
             {
-              echo "Release $VERSION"
-              echo ""
-              echo "**Version bump**: $BUMP_TYPE"
+              printf 'Release %s\n\n' "$VERSION"
+              printf '**Version bump**: %s\n' "$BUMP_TYPE"
             } > /tmp/release_notes.md
           fi
           
@@ -158,12 +158,10 @@ jobs:
           git push origin "$TAG"
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.new_version.outputs.tag }}
-          release_name: Release ${{ steps.new_version.outputs.tag }}
+          name: Release ${{ steps.new_version.outputs.tag }}
           body_path: /tmp/release_notes.md
           draft: false
           prerelease: false


### PR DESCRIPTION
This pull request updates the release workflow to improve reliability and compatibility with GitHub Actions. The changes focus on how release notes are generated and which action is used to create GitHub releases.

Release notes generation improvements:

* Changed release notes creation to use PR metadata (`title` and `body`) from the event payload via `jq`, rather than shell interpolation, to avoid parsing issues. (`.github/workflows/release.yml`)
* Updated formatting of release notes to use `printf` for greater consistency and safety. (`.github/workflows/release.yml`)

GitHub release action update:

* Switched from `actions/create-release@v1` to `softprops/action-gh-release@v2` for creating releases, improving compatibility and maintainability. (`.github/workflows/release.yml`)
* Adjusted input parameters for the new release action, including renaming `release_name` to `name` for the release title. (`.github/workflows/release.yml`)