### PR TITLE
network usage for UDP/TCP sockets added

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - **Process Memory Layout**: Code, Data, BSS, Heap, and Stack addresses
 - **Memory Pressure Monitoring**: RSS, VSZ, swap usage, page faults (major/minor), and OOM score adjustment
 - **Visual Memory Map**: Proportional bar chart visualization of memory regions
-- **Open Sockets**: List all open sockets with family (IPv4/IPv6/Unix), type, state, and addresses
+- **Open Sockets**: List all open sockets with family, type, state, protocol, addresses, and per-socket traffic stats
 - **Network Stats (Brief)**: Per-process TCP counters, socket counts (TCP/UDP/UNIX), drops, and net devices
 - **Thread Information**: List all threads with TID, state, CPU usage, priority, and CPU affinity
 - **CPU Usage Tracking**: Real-time CPU percentage calculation per process and thread
@@ -109,27 +109,29 @@ net_devices: lo=1 eth0=1
 
 Open Sockets:
 --------------------------------------------------------------------------------
- [FD 0] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 1] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 2] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 3] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 23] Family: AF_INET     Type: STREAM    State: ESTABLISHED  
+ [FD 0] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 1] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 2] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 3] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 23] Family: AF_INET     Type: STREAM    State: ESTABLISHED   Proto: TCP
+   Traffic: RX pkts=238 bytes=150387  TX pkts=241 bytes=147030
          Local:  127.0.0.1:[REDACTED]  Remote: 127.0.0.1:[REDACTED]
- [FD 26] Family: AF_UNIX     Type: STREAM    State: LISTEN       
- [FD 36] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 37] Family: AF_UNIX     Type: STREAM    State: LISTEN       
- [FD 39] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 41] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 43] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 45] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 49] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 50] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 51] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 53] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 57] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED  
- [FD 59] Family: AF_INET     Type: STREAM    State: ESTABLISHED  
+ [FD 26] Family: AF_UNIX     Type: STREAM    State: LISTEN        Proto: OTHER
+ [FD 36] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 37] Family: AF_UNIX     Type: STREAM    State: LISTEN        Proto: OTHER
+ [FD 39] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 41] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 43] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 45] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 49] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 50] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 51] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 53] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 57] Family: AF_UNIX     Type: STREAM    State: ESTABLISHED   Proto: OTHER
+ [FD 59] Family: AF_INET     Type: STREAM    State: ESTABLISHED   Proto: TCP
+   Traffic: RX pkts=671 bytes=512004  TX pkts=653 bytes=233911
          Local:  [INTERNAL_IP]:[PORT]  Remote: [REDACTED_PUBLIC_IP]:443
- [FD 62] Family: AF_UNIX     Type: STREAM    State: LISTEN       
+ [FD 62] Family: AF_UNIX     Type: STREAM    State: LISTEN        Proto: OTHER
 --------------------------------------------------------------------------------
 
 ===============================================================
@@ -284,8 +286,9 @@ kernel_module/
 - Sizes are automatically displayed in appropriate units (B, KB, or MB)
 - Low/High addresses show the memory address range of the process
 - BSS_START and BSS_END may be equal (zero-length BSS) in modern ELF binaries. This is normal.
-- **Open Sockets**: Shows file descriptor, socket family (AF_INET, AF_INET6, AF_UNIX), type (STREAM/DGRAM), state, and addresses
+- **Open Sockets**: Shows file descriptor, socket family, type, state, protocol, addresses, and traffic stats for TCP/UDP sockets
 - Socket families: AF_INET (IPv4), AF_INET6 (IPv6), AF_UNIX (Unix domain), AF_NETLINK (Netlink)
+- UDP traffic values are queue-based (current queued packets/bytes), while TCP traffic values are lifetime socket counters.
 - Thread STATE: R=Running, S=Sleeping, D=Uninterruptible, T=Stopped, t=Traced, Z=Zombie, X=Dead
 - PRIORITY: Shown as nice value (-20 to 19, where lower is higher priority)
 - CPU_AFFINITY: Shows which CPUs the thread can run on

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -51,10 +51,17 @@ The process information output includes an open sockets section that lists all o
 | **Family** | Socket address family | AF_INET, AF_INET6, AF_UNIX, AF_NETLINK, etc. |
 | **Type** | Socket type | STREAM (TCP), DGRAM (UDP), RAW |
 | **State** | Connection state (TCP) | ESTABLISHED, LISTEN, CLOSE_WAIT, etc. |
+| **Proto** | Socket protocol | TCP, UDP, or OTHER |
+| **Traffic** | Per-socket RX/TX packet and byte counters | TCP: lifetime counters; UDP: current queue counters |
 | **Local** | Local address and port | IPv4 (e.g., 127.0.0.1:8080) or IPv6 format |
 | **Remote** | Remote address and port | Destination address for connected sockets |
 
 The socket listing provides visibility into network connections and IPC sockets in use by the process. For processes with no open sockets, displays "No open sockets".
+
+Notes:
+- TCP traffic values come from `struct tcp_sock` counters (`segs_in`, `segs_out`, `bytes_received`, `bytes_sent`).
+- UDP traffic values are queue-based snapshots (`sk_receive_queue`, `sk_write_queue`, `sk_rmem_alloc`, `sk_wmem_queued`).
+- Protocols other than TCP/UDP are labeled `OTHER` and do not include a traffic line.
 
 ### Network Stats (Brief)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -173,6 +173,8 @@ The socket output should include:
 - Socket family (AF_INET, AF_INET6, AF_UNIX, AF_NETLINK)
 - Socket type (STREAM, DGRAM, RAW)
 - Connection state (ESTABLISHED, LISTEN, CLOSE_WAIT, etc.)
+- Protocol label (TCP, UDP, OTHER)
+- Per-socket traffic line for TCP/UDP sockets (`Traffic: RX ... TX ...`)
 - Local and remote addresses/ports for inet sockets
 - IPv6 addresses in full format
 
@@ -193,6 +195,10 @@ Look for:
 
 Note: RX/TX bytes and packets are aggregated from TCP sockets only. UNIX
 sockets are counted but do not contribute to byte/packet totals.
+
+In the open sockets section:
+- TCP sockets include lifetime packet/byte counters.
+- UDP sockets include queue-based packet/byte counters (current queued data).
 
 ## Test Coverage
 

--- a/e2e/qemu-test.sh
+++ b/e2e/qemu-test.sh
@@ -78,6 +78,15 @@ if ! echo "$PROC_OUT" | grep -q "Open Sockets"; then
     echo "[FAIL] Open sockets section missing for PID $$"
     exit 1
 fi
+if ! echo "$PROC_OUT" | grep -q "Proto:"; then
+    echo "[FAIL] Open sockets protocol field missing for PID $$"
+    exit 1
+fi
+if echo "$PROC_OUT" | grep -Eq "Proto: +TCP|Proto: +UDP" && \
+   ! echo "$PROC_OUT" | grep -q "Traffic: RX"; then
+    echo "[FAIL] Per-socket traffic stats missing for TCP/UDP sockets (PID $$)"
+    exit 1
+fi
 
 echo ""
 echo "=== Testing Thread Information (PID: $$) ==="
@@ -107,6 +116,15 @@ if ! echo "$PROC_OUT" | grep -q "net_devices:"; then
 fi
 if ! echo "$PROC_OUT" | grep -q "Open Sockets"; then
     echo "[FAIL] Open sockets section missing for PID 1"
+    exit 1
+fi
+if ! echo "$PROC_OUT" | grep -q "Proto:"; then
+    echo "[FAIL] Open sockets protocol field missing for PID 1"
+    exit 1
+fi
+if echo "$PROC_OUT" | grep -Eq "Proto: +TCP|Proto: +UDP" && \
+   ! echo "$PROC_OUT" | grep -q "Traffic: RX"; then
+    echo "[FAIL] Per-socket traffic stats missing for TCP/UDP sockets (PID 1)"
     exit 1
 fi
 echo ""
@@ -153,6 +171,15 @@ if ! echo "$PROC_OUT" | grep -q "net_devices:"; then
 fi
 if ! echo "$PROC_OUT" | grep -q "Open Sockets"; then
     echo "[FAIL] Open sockets section missing for PID $MULTITHREAD_PID"
+    exit 1
+fi
+if ! echo "$PROC_OUT" | grep -q "Proto:"; then
+    echo "[FAIL] Open sockets protocol field missing for PID $MULTITHREAD_PID"
+    exit 1
+fi
+if echo "$PROC_OUT" | grep -Eq "Proto: +TCP|Proto: +UDP" && \
+   ! echo "$PROC_OUT" | grep -q "Traffic: RX"; then
+    echo "[FAIL] Per-socket traffic stats missing for TCP/UDP sockets (PID $MULTITHREAD_PID)"
     exit 1
 fi
 echo ""

--- a/src/elf_det.c
+++ b/src/elf_det.c
@@ -396,12 +396,18 @@ static void print_sockets(struct seq_file *m, struct task_struct *task)
 	struct socket *sock;
 	struct sock *sk;
 	struct inet_sock *inet;
+	struct tcp_sock *tp;
 	unsigned int fd;
 	int socket_count = 0;
 	unsigned short family, type;
 	unsigned char state;
+	const char *protocol;
 	__be32 saddr, daddr;
 	__be16 sport, dport;
+	u64 rx_packets, tx_packets, rx_bytes, tx_bytes;
+	u32 udp_rx_packets, udp_tx_packets;
+	char traffic_line[160];
+	int traffic_len;
 	int i;
 
 	files = task->files;
@@ -435,13 +441,37 @@ static void print_sockets(struct seq_file *m, struct task_struct *task)
 		family = sk->sk_family;
 		type = sk->sk_type;
 		state = sk->sk_state;
+		protocol = socket_protocol_to_string(sk->sk_protocol);
 
-		seq_printf(
-			m,
-			"  [FD %u] Family: %-10s  Type: %-8s  State: %-12s\n",
-			fd, socket_family_to_string(family),
-			socket_type_to_string(type),
-			socket_state_to_string(state));
+		seq_printf(m,
+			   "  [FD %u] Family: %-10s  Type: %-8s  State: %-12s  "
+			   "Proto: %-5s\n",
+			   fd, socket_family_to_string(family),
+			   socket_type_to_string(type),
+			   socket_state_to_string(state), protocol);
+
+		if (sk->sk_protocol == IPPROTO_TCP) {
+			tp = tcp_sk(sk);
+			rx_packets = (u64)READ_ONCE(tp->segs_in);
+			tx_packets = (u64)READ_ONCE(tp->segs_out);
+			rx_bytes = (u64)READ_ONCE(tp->bytes_received);
+			tx_bytes = (u64)READ_ONCE(tp->bytes_sent);
+			traffic_len = format_tcp_traffic_line(
+				rx_packets, rx_bytes, tx_packets, tx_bytes,
+				traffic_line, sizeof(traffic_line));
+			if (traffic_len > 0)
+				seq_puts(m, traffic_line);
+		} else if (sk->sk_protocol == IPPROTO_UDP) {
+			udp_rx_packets = skb_queue_len(&sk->sk_receive_queue);
+			udp_tx_packets = skb_queue_len(&sk->sk_write_queue);
+			rx_bytes = (u64)sk_rmem_alloc_get(sk);
+			tx_bytes = (u64)READ_ONCE(sk->sk_wmem_queued);
+			traffic_len = format_udp_traffic_line(
+				udp_rx_packets, rx_bytes, udp_tx_packets,
+				tx_bytes, traffic_line, sizeof(traffic_line));
+			if (traffic_len > 0)
+				seq_puts(m, traffic_line);
+		}
 
 		/* Display address information for inet sockets */
 		if (family == AF_INET && sk->sk_prot) {

--- a/src/elf_det.h
+++ b/src/elf_det.h
@@ -466,6 +466,61 @@ static inline const char *socket_type_to_string(unsigned short type)
 	}
 }
 
+/* Convert socket protocol value to string representation
+ * Common values: TCP (6), UDP (17)
+ * Returns "OTHER" for unrecognized protocols
+ * For testing: use numeric values (6, 17)
+ */
+static inline const char *socket_protocol_to_string(unsigned short protocol)
+{
+	switch (protocol) {
+	case 6: /* IPPROTO_TCP */
+		return "TCP";
+	case 17: /* IPPROTO_UDP */
+		return "UDP";
+	default:
+		return "OTHER";
+	}
+}
+
+/* Format TCP per-socket traffic statistics line
+ * Returns number of characters written
+ */
+static inline int format_tcp_traffic_line(eh_u64 rx_packets,
+					  eh_u64 rx_bytes,
+					  eh_u64 tx_packets,
+					  eh_u64 tx_bytes,
+					  char *out_buf,
+					  int buf_size)
+{
+	if (!out_buf || buf_size < 80)
+		return 0;
+
+	return snprintf(out_buf, buf_size,
+			"          Traffic: RX pkts=%llu bytes=%llu  TX "
+			"pkts=%llu bytes=%llu\n",
+			rx_packets, rx_bytes, tx_packets, tx_bytes);
+}
+
+/* Format UDP per-socket traffic statistics line (queue snapshot)
+ * Returns number of characters written
+ */
+static inline int format_udp_traffic_line(eh_u64 rx_packets,
+					  eh_u64 rx_bytes,
+					  eh_u64 tx_packets,
+					  eh_u64 tx_bytes,
+					  char *out_buf,
+					  int buf_size)
+{
+	if (!out_buf || buf_size < 90)
+		return 0;
+
+	return snprintf(out_buf, buf_size,
+			"          Traffic: RX pkts=%llu bytes=%llu  TX "
+			"pkts=%llu bytes=%llu (queued)\n",
+			rx_packets, rx_bytes, tx_packets, tx_bytes);
+}
+
 /* Convert TCP socket state value to string representation
  * TCP state values: 1-12 representing connection states
  * Returns string representation or "UNKNOWN" for invalid states

--- a/src/elf_det_tests.c
+++ b/src/elf_det_tests.c
@@ -447,6 +447,42 @@ int main(void)
 	type_str = socket_type_to_string(0);
 	assert(strcmp(type_str, "UNKNOWN") == 0);
 
+	/* socket_protocol_to_string tests */
+	const char *proto_str;
+
+	proto_str = socket_protocol_to_string(6); /* IPPROTO_TCP */
+	assert(strcmp(proto_str, "TCP") == 0);
+
+	proto_str = socket_protocol_to_string(17); /* IPPROTO_UDP */
+	assert(strcmp(proto_str, "UDP") == 0);
+
+	proto_str = socket_protocol_to_string(1); /* ICMP */
+	assert(strcmp(proto_str, "OTHER") == 0);
+
+	proto_str = socket_protocol_to_string(0);
+	assert(strcmp(proto_str, "OTHER") == 0);
+
+	/* traffic line formatting tests */
+	char traffic_buf[200];
+
+	len = format_tcp_traffic_line(10, 2048, 11, 3072, traffic_buf,
+				      sizeof(traffic_buf));
+	assert(len > 0);
+	assert(strcmp(traffic_buf, "          Traffic: RX pkts=10 bytes=2048  "
+				   "TX pkts=11 bytes=3072\n") == 0);
+
+	len = format_udp_traffic_line(3, 512, 4, 1024, traffic_buf,
+				      sizeof(traffic_buf));
+	assert(len > 0);
+	assert(strcmp(traffic_buf, "          Traffic: RX pkts=3 bytes=512  TX "
+				   "pkts=4 bytes=1024 (queued)\n") == 0);
+
+	len = format_tcp_traffic_line(1, 1, 1, 1, NULL, sizeof(traffic_buf));
+	assert(len == 0);
+
+	len = format_udp_traffic_line(1, 1, 1, 1, traffic_buf, 10);
+	assert(len == 0);
+
 	/* socket_state_to_string tests */
 	const char *state_str;
 


### PR DESCRIPTION
This pull request enhances the open sockets reporting feature by adding protocol identification and per-socket traffic statistics for TCP and UDP sockets. It updates both the kernel module and user-facing documentation, and introduces new tests to ensure these features are correctly reported and validated.

**Open Sockets Reporting Enhancements:**

- Each socket entry now includes a `Proto` field that labels the protocol as `TCP`, `UDP`, or `OTHER`, improving clarity about the type of traffic each socket handles. [[1]](diffhunk://#diff-5f9ebd21d042c407eed8fe626f18e87a7271bc5679ae07c30fe926b42fa17bdfR444-R474) [[2]](diffhunk://#diff-ac671f57ae70972d746a477bd9657a15236f309a371c8f3bf472ab0239f8cd56R469-R523)
- For TCP and UDP sockets, a new `Traffic` line displays per-socket RX/TX packet and byte counters. TCP values are lifetime counters, while UDP values show current queue statistics. [[1]](diffhunk://#diff-5f9ebd21d042c407eed8fe626f18e87a7271bc5679ae07c30fe926b42fa17bdfR444-R474) [[2]](diffhunk://#diff-ac671f57ae70972d746a477bd9657a15236f309a371c8f3bf472ab0239f8cd56R469-R523)
- Helper functions for protocol string conversion and traffic formatting have been added to `elf_det.h`, along with corresponding unit tests in `elf_det_tests.c`. [[1]](diffhunk://#diff-ac671f57ae70972d746a477bd9657a15236f309a371c8f3bf472ab0239f8cd56R469-R523) [[2]](diffhunk://#diff-d6b22b97c47ceeb1b193432f1b6f3771fdba0e294f305273ce438750b9b3de3dR450-R485)

**Documentation Updates:**

- The `README.md`, `docs/TECHNICAL.md`, and `docs/TESTING.md` files have been updated to describe the new protocol and traffic fields, and to clarify the meaning and source of the reported statistics. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R134) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L287-R291) [[4]](diffhunk://#diff-90125689b9e777835e5f6ed42276923d217bcf51cd795dec699621248b461aa2R54-R65) [[5]](diffhunk://#diff-63e3617f53c4cb117c1586d6d639e52d8541a37b0f41ca1bae6f9422e0036270R176-R177) [[6]](diffhunk://#diff-63e3617f53c4cb117c1586d6d639e52d8541a37b0f41ca1bae6f9422e0036270R199-R202)

**Testing Improvements:**

- End-to-end tests in `e2e/qemu-test.sh` now check for the presence of the `Proto` field and the per-socket `Traffic` line for TCP/UDP sockets, ensuring the new features are present and correctly formatted in the output. [[1]](diffhunk://#diff-0c964d7c4e527d54d2602a221688d442b5f3445377d5e60752906e3d0fd2dbecR81-R89) [[2]](diffhunk://#diff-0c964d7c4e527d54d2602a221688d442b5f3445377d5e60752906e3d0fd2dbecR121-R129) [[3]](diffhunk://#diff-0c964d7c4e527d54d2602a221688d442b5f3445377d5e60752906e3d0fd2dbecR176-R184)