### PR TITLE
Add per-process network top talkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - **Memory Pressure Monitoring**: RSS, VSZ, swap usage, page faults (major/minor), and OOM score adjustment
 - **Visual Memory Map**: Proportional bar chart visualization of memory regions
 - **Open Sockets**: List all open sockets with family, type, state, protocol, addresses, and per-socket traffic stats
-- **Network Stats (Brief)**: Per-process TCP counters, socket counts (TCP/UDP/UNIX), drops, and net devices
+- **Network Stats (Brief)**: Per-process TCP counters, socket counts (TCP/UDP/UNIX), drops, net devices, and top talkers
 - **Thread Information**: List all threads with TID, state, CPU usage, priority, and CPU affinity
 - **CPU Usage Tracking**: Real-time CPU percentage calculation per process and thread
 - **ELF Section Analysis**: Binary base address and section boundaries
@@ -106,6 +106,9 @@ tx_bytes: 37736732
 tcp_retransmits: 0
 drops: 0
 net_devices: lo=1 eth0=1
+top_talkers:
+  #1 FD 59 Proto: TCP   Family: AF_INET    RX bytes=512004 TX bytes=233911 Total bytes=745915
+  #2 FD 23 Proto: TCP   Family: AF_INET    RX bytes=150387 TX bytes=147030 Total bytes=297417
 
 Open Sockets:
 --------------------------------------------------------------------------------
@@ -289,6 +292,7 @@ ProcLens/
 - **Open Sockets**: Shows file descriptor, socket family, type, state, protocol, addresses, and traffic stats for TCP/UDP sockets
 - Socket families: AF_INET (IPv4), AF_INET6 (IPv6), AF_UNIX (Unix domain), AF_NETLINK (Netlink)
 - UDP traffic values are queue-based (current queued packets/bytes), while TCP traffic values are lifetime socket counters.
+- **Top Talkers**: The `[network]` section includes up to three sockets ranked by total bytes (`RX + TX`) at read time.
 - Thread STATE: R=Running, S=Sleeping, D=Uninterruptible, T=Stopped, t=Traced, Z=Zombie, X=Dead
 - PRIORITY: Shown as nice value (-20 to 19, where lower is higher priority)
 - CPU_AFFINITY: Shows which CPUs the thread can run on

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -77,10 +77,12 @@ The process information output includes a brief network stats section, aggregate
 | **tcp_retransmits** | TCP retransmitted segments | `struct tcp_sock::retrans_out` |
 | **drops** | Raw/UDP drops | `struct sock::sk_drops` |
 | **net_devices** | Device names with socket counts | `sk_bound_dev_if` or `sk_rx_dst_ifindex` |
+| **top_talkers** | Up to 3 sockets ranked by total bytes (RX + TX) | Per-socket TCP lifetime bytes, UDP queued bytes |
 
 Notes:
 - Packet and byte counters are best-effort and only reflect TCP sockets. UDP and UNIX sockets are counted but do not contribute to byte/packet totals.
 - Device mapping uses the socket bound interface or RX route ifindex; if neither is set, the socket is not attributed to a device.
+- Top talkers ranking can include UDP sockets using queued RX/TX memory (`sk_rmem_alloc` + `sk_wmem_queued`).
 
 ### Important Notes and Limitations
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -193,9 +193,16 @@ Look for:
 - `[network]`
 - `sockets_total:`
 - `net_devices:`
+- `top_talkers:`
 
 Note: RX/TX bytes and packets are aggregated from TCP sockets only. UNIX
 sockets are counted but do not contribute to byte/packet totals.
+
+Top talkers behavior:
+- Up to three sockets are listed in descending `RX + TX` byte order.
+- TCP entries use lifetime byte counters.
+- UDP entries use queue-based byte snapshots.
+- If no socket has byte activity, the section displays `none`.
 
 In the open sockets section:
 - TCP sockets include lifetime packet/byte counters.

--- a/e2e/qemu-test.sh
+++ b/e2e/qemu-test.sh
@@ -101,6 +101,10 @@ if ! echo "$PROC_OUT" | grep -q "net_devices:"; then
     echo "[FAIL] Network net_devices missing for PID $$"
     exit 1
 fi
+if ! echo "$PROC_OUT" | grep -q "top_talkers:"; then
+    echo "[FAIL] Network top_talkers missing for PID $$"
+    exit 1
+fi
 if ! echo "$PROC_OUT" | grep -q "Open Sockets"; then
     echo "[FAIL] Open sockets section missing for PID $$"
     exit 1
@@ -141,6 +145,10 @@ if ! echo "$PROC_OUT" | grep -q "sockets_total:"; then
 fi
 if ! echo "$PROC_OUT" | grep -q "net_devices:"; then
     echo "[FAIL] Network net_devices missing for PID 1"
+    exit 1
+fi
+if ! echo "$PROC_OUT" | grep -q "top_talkers:"; then
+    echo "[FAIL] Network top_talkers missing for PID 1"
     exit 1
 fi
 if ! echo "$PROC_OUT" | grep -q "Open Sockets"; then
@@ -198,6 +206,10 @@ if ! echo "$PROC_OUT" | grep -q "sockets_total:"; then
 fi
 if ! echo "$PROC_OUT" | grep -q "net_devices:"; then
     echo "[FAIL] Network net_devices missing for PID $MULTITHREAD_PID"
+    exit 1
+fi
+if ! echo "$PROC_OUT" | grep -q "top_talkers:"; then
+    echo "[FAIL] Network top_talkers missing for PID $MULTITHREAD_PID"
     exit 1
 fi
 if ! echo "$PROC_OUT" | grep -q "Open Sockets"; then

--- a/src/elf_det.c
+++ b/src/elf_det.c
@@ -299,14 +299,19 @@ static void print_network_stats(struct seq_file *m, struct task_struct *task)
 	u64 rx_packets = 0, tx_packets = 0;
 	u64 rx_bytes = 0, tx_bytes = 0;
 	u64 tcp_retransmits = 0;
+	u64 socket_rx_bytes, socket_tx_bytes;
 	u64 drops = 0;
 	int socket_total = 0, tcp_count = 0, udp_count = 0, unix_count = 0;
 	struct netdev_count netdevs[ELF_DET_NETDEV_MAX];
 	int netdev_len = 0;
+	struct top_talker_entry top_talkers[ELF_DET_TOP_TALKERS_MAX];
+	int top_talker_len = 0;
 	int ifindex;
 	struct net_device *dev;
 	const char *dev_name;
 	int i;
+
+	memset(top_talkers, 0, sizeof(top_talkers));
 
 	files = task->files;
 	if (!files)
@@ -331,6 +336,9 @@ static void print_network_stats(struct seq_file *m, struct task_struct *task)
 		if (!sk)
 			continue;
 
+		socket_rx_bytes = 0;
+		socket_tx_bytes = 0;
+
 		drops += (u64)atomic_read(&sk->sk_drops);
 
 		if (sk->sk_protocol == IPPROTO_TCP) {
@@ -338,15 +346,24 @@ static void print_network_stats(struct seq_file *m, struct task_struct *task)
 			tcp_count++;
 			rx_packets += (u64)READ_ONCE(tp->segs_in);
 			tx_packets += (u64)READ_ONCE(tp->segs_out);
-			rx_bytes += (u64)READ_ONCE(tp->bytes_received);
-			tx_bytes += (u64)READ_ONCE(tp->bytes_sent);
+			socket_rx_bytes = (u64)READ_ONCE(tp->bytes_received);
+			socket_tx_bytes = (u64)READ_ONCE(tp->bytes_sent);
+			rx_bytes += socket_rx_bytes;
+			tx_bytes += socket_tx_bytes;
 			tcp_retransmits += (u64)READ_ONCE(tp->retrans_out);
 		} else if (sk->sk_protocol == IPPROTO_UDP) {
 			udp_count++;
+			socket_rx_bytes = (u64)sk_rmem_alloc_get(sk);
+			socket_tx_bytes = (u64)READ_ONCE(sk->sk_wmem_queued);
 		}
 
 		if (sk->sk_family == AF_UNIX)
 			unix_count++;
+
+		try_insert_top_talker(top_talkers, &top_talker_len,
+				      ELF_DET_TOP_TALKERS_MAX, fd,
+				      sk->sk_family, sk->sk_protocol,
+				      socket_rx_bytes, socket_tx_bytes);
 
 		ifindex = READ_ONCE(sk->sk_bound_dev_if);
 		if (!ifindex)
@@ -373,16 +390,32 @@ static void print_network_stats(struct seq_file *m, struct task_struct *task)
 
 	if (netdev_len == 0) {
 		seq_puts(m, "net_devices: none\n");
+	} else {
+		seq_puts(m, "net_devices: ");
+		for (i = 0; i < netdev_len; i++) {
+			seq_printf(m, "%s=%d", netdevs[i].name,
+				   netdevs[i].count);
+			if (i + 1 < netdev_len)
+				seq_puts(m, " ");
+		}
+		seq_puts(m, "\n");
+	}
+
+	seq_puts(m, "top_talkers:\n");
+	if (top_talker_len == 0) {
+		seq_puts(m, "  none\n");
 		return;
 	}
 
-	seq_puts(m, "net_devices: ");
-	for (i = 0; i < netdev_len; i++) {
-		seq_printf(m, "%s=%d", netdevs[i].name, netdevs[i].count);
-		if (i + 1 < netdev_len)
-			seq_puts(m, " ");
+	for (i = 0; i < top_talker_len; i++) {
+		seq_printf(m, "  #%d FD %u Proto: %-5s Family: %-10s ", i + 1,
+			   top_talkers[i].fd,
+			   socket_protocol_to_string(top_talkers[i].protocol),
+			   socket_family_to_string(top_talkers[i].family));
+		seq_printf(m, "RX bytes=%llu TX bytes=%llu Total bytes=%llu\n",
+			   top_talkers[i].rx_bytes, top_talkers[i].tx_bytes,
+			   top_talkers[i].total_bytes);
 	}
-	seq_puts(m, "\n");
 }
 
 /* Display open socket information for the process

--- a/src/elf_det.h
+++ b/src/elf_det.h
@@ -213,12 +213,82 @@ struct memory_region {
 
 #define ELF_DET_NETDEV_MAX	8
 #define ELF_DET_NETDEV_NAME_MAX IFNAMSIZ
+#define ELF_DET_TOP_TALKERS_MAX 3
 
 struct netdev_count {
 	int ifindex;
 	int count;
 	char name[ELF_DET_NETDEV_NAME_MAX];
 };
+
+struct top_talker_entry {
+	unsigned int fd;
+	unsigned short family;
+	unsigned short protocol;
+	eh_u64 rx_bytes;
+	eh_u64 tx_bytes;
+	eh_u64 total_bytes;
+};
+
+/* Insert/keep top sockets by total bytes in descending order.
+ * Entries with total_bytes == 0 are ignored.
+ */
+static inline void try_insert_top_talker(struct top_talker_entry *list,
+					 int *list_len,
+					 int max_entries,
+					 unsigned int fd,
+					 unsigned short family,
+					 unsigned short protocol,
+					 eh_u64 rx_bytes,
+					 eh_u64 tx_bytes)
+{
+	int i;
+	int insert_at;
+	int current_len;
+	eh_u64 total_bytes;
+	struct top_talker_entry entry;
+
+	if (!list || !list_len || max_entries <= 0)
+		return;
+
+	total_bytes = rx_bytes + tx_bytes;
+	if (total_bytes == 0)
+		return;
+
+	entry.fd = fd;
+	entry.family = family;
+	entry.protocol = protocol;
+	entry.rx_bytes = rx_bytes;
+	entry.tx_bytes = tx_bytes;
+	entry.total_bytes = total_bytes;
+
+	current_len = *list_len;
+	if (current_len > max_entries)
+		current_len = max_entries;
+
+	insert_at = current_len;
+	for (i = 0; i < current_len; i++) {
+		if (total_bytes > list[i].total_bytes) {
+			insert_at = i;
+			break;
+		}
+	}
+
+	if (current_len < max_entries) {
+		for (i = current_len; i > insert_at; i--)
+			list[i] = list[i - 1];
+		list[insert_at] = entry;
+		*list_len = current_len + 1;
+		return;
+	}
+
+	if (insert_at >= max_entries)
+		return;
+
+	for (i = max_entries - 1; i > insert_at; i--)
+		list[i] = list[i - 1];
+	list[insert_at] = entry;
+}
 
 /* Format size with appropriate unit (B, KB, MB)
  * Returns number of characters written (excluding null terminator)

--- a/src/elf_det_tests.c
+++ b/src/elf_det_tests.c
@@ -483,6 +483,41 @@ int main(void)
 	len = format_udp_traffic_line(1, 1, 1, 1, traffic_buf, 10);
 	assert(len == 0);
 
+	/* top talkers ranking tests */
+	struct top_talker_entry talkers[ELF_DET_TOP_TALKERS_MAX];
+	int talker_len = 0;
+
+	memset(talkers, 0, sizeof(talkers));
+
+	try_insert_top_talker(talkers, &talker_len, ELF_DET_TOP_TALKERS_MAX, 10,
+			      2, 6, 500, 500);
+	assert(talker_len == 1);
+	assert(talkers[0].fd == 10);
+	assert(talkers[0].total_bytes == 1000);
+
+	try_insert_top_talker(talkers, &talker_len, ELF_DET_TOP_TALKERS_MAX, 20,
+			      2, 6, 100, 100);
+	try_insert_top_talker(talkers, &talker_len, ELF_DET_TOP_TALKERS_MAX, 30,
+			      1, 17, 700, 500);
+	assert(talker_len == 3);
+	assert(talkers[0].fd == 30);
+	assert(talkers[0].total_bytes == 1200);
+	assert(talkers[1].fd == 10);
+	assert(talkers[2].fd == 20);
+
+	/* Replaces the current lowest-ranked entry */
+	try_insert_top_talker(talkers, &talker_len, ELF_DET_TOP_TALKERS_MAX, 40,
+			      10, 6, 300, 300);
+	assert(talker_len == 3);
+	assert(talkers[2].fd == 40);
+	assert(talkers[2].total_bytes == 600);
+
+	/* Zero-traffic entries are ignored */
+	try_insert_top_talker(talkers, &talker_len, ELF_DET_TOP_TALKERS_MAX, 50,
+			      2, 6, 0, 0);
+	assert(talker_len == 3);
+	assert(talkers[0].fd == 30);
+
 	/* socket_state_to_string tests */
 	const char *state_str;
 


### PR DESCRIPTION
This pull request introduces a new **"Top Talkers"** feature to the network statistics section, which highlights the most active sockets by total bytes transferred. It updates documentation, adds kernel logic for ranking sockets, and ensures test coverage for this feature. The changes improve visibility into per-process network activity and help identify high-traffic sockets.

---

### Feature: Top Talkers in Network Stats

* **Output Integration:** Added a "Top Talkers" section to the `[network]` output, showing up to three sockets ranked by total bytes (RX + TX) at read time, including TCP lifetime counters and UDP queue-based snapshots.
* **Kernel Implementation:** Updated the kernel logic to track and rank socket activity, including a new `top_talker_entry` struct and insertion logic (`try_insert_top_talker`).
* **End-to-End Testing:** Enhanced tests to require the presence of the `top_talkers:` section for all relevant processes.
* **Unit Testing:** Added unit tests for the ranking and insertion logic of top talkers in `elf_det_tests.c`.

### Documentation Updates

* Updated `README.md`, `TECHNICAL.md`, and `TESTING.md` to describe the new "Top Talkers" feature, its behavior, and its output format.