### PR TITLE
logo and testing with the kernel module inserted tested at user side

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -177,6 +177,9 @@ Verify no-argument live mode behavior:
 ```
 
 Expected behavior:
+- Program prints the startup logo once, then validates module/proc readiness
+- If `elf_det` is not loaded, program exits immediately with status `-1`
+- If required proc files are missing (`pid`, `det`, `threads`), program exits immediately with status `-1`
 - Screen refreshes every 1 second
 - Header shows controls (`1` memory, `2` network, `3` threads, `0` switch PID)
 - Each refresh shows `Snapshot start` and `Snapshot end` timestamps in `YY/MM/DD HH:MM:SS`

--- a/src/proc_elf_ctrl.c
+++ b/src/proc_elf_ctrl.c
@@ -77,9 +77,10 @@ static int set_raw_mode(void)
 	return 0;
 }
 
-#define PID_INPUT_MAX 20
-#define PROC_BUF_SIZE 262144
-#define MAX_SNAPSHOTS 120
+#define PID_INPUT_MAX	20
+#define PROC_BUF_SIZE	262144
+#define MAX_SNAPSHOTS	120
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
 enum view_mode {
 	VIEW_MEMORY = 1,
@@ -94,6 +95,102 @@ struct live_snapshot {
 	char *det_content;
 	char *threads_content;
 };
+
+static void print_logo_text(void)
+{
+	printf("%s%s\n", color_code(C_CYAN), color_code(C_BOLD));
+	/* clang-format off */
+	puts(" /$$$$$$$                               /$$                                    ");
+	puts("| $$__  $$                             | $$                                    ");
+	puts("| $$  \\ $$ /$$$$$$   /$$$$$$   /$$$$$$$| $$        /$$$$$$  /$$$$$$$   /$$$$$$$");
+	puts("| $$$$$$$//$$__  $$ /$$__  $$ /$$_____/| $$       /$$__  $$| $$__  $$ /$$_____/");
+	puts("| $$____/| $$  \\__/| $$  \\ $$| $$      | $$      | $$$$$$$$| $$  \\ $$|  $$$$$$ ");
+	puts("| $$     | $$      | $$  | $$| $$      | $$      | $$_____/| $$  | $$ \\____  $$");
+	puts("| $$     | $$      |  $$$$$$/|  $$$$$$$| $$$$$$$$|  $$$$$$$| $$  | $$ /$$$$$$$/");
+	puts("|__/     |__/       \\______/  \\_______/|________/ \\_______/|__/  |__/|_______/ ");
+	puts("                                                                               ");
+	puts("                                                                               ");
+	puts("                                                                               ");
+	/* clang-format on */
+	printf("%s\n", color_code(C_RESET));
+}
+
+static int is_module_loaded(const char *module_name)
+{
+	FILE *fp;
+	char line[256];
+	size_t module_name_len;
+
+	fp = fopen("/proc/modules", "r");
+	if (!fp)
+		return -1;
+
+	module_name_len = strlen(module_name);
+	while (fgets(line, sizeof(line), fp)) {
+		if (strncmp(line, module_name, module_name_len) == 0 &&
+		    line[module_name_len] == ' ') {
+			fclose(fp);
+			return 1;
+		}
+	}
+
+	fclose(fp);
+	return 0;
+}
+
+static int ensure_module_loaded(void)
+{
+	int loaded;
+
+	loaded = is_module_loaded("elf_det");
+	if (loaded < 0) {
+		perror("open /proc/modules");
+		return -1;
+	}
+
+	if (loaded == 0) {
+		fprintf(stderr,
+			"%serror:%s kernel module 'elf_det' is not loaded\n",
+			color_code(C_YELLOW), color_code(C_RESET));
+		fprintf(stderr, "hint: run 'sudo insmod ./build/elf_det.ko' or "
+				"'sudo make install'\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int ensure_proc_files_present(void)
+{
+	static const char *const required_files[] = {"pid", "det", "threads"};
+	char *path;
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(required_files); i++) {
+		path = build_proc_path(required_files[i]);
+		if (!path) {
+			fprintf(stderr, "failed to allocate path for proc "
+					"interface check\n");
+			return -1;
+		}
+
+		if (access(path, F_OK) != 0) {
+			fprintf(stderr,
+				"%serror:%s required proc file is missing: "
+				"%s\n",
+				color_code(C_YELLOW), color_code(C_RESET),
+				path);
+			fprintf(stderr, "hint: confirm /proc/elf_det is "
+					"mounted and initialized\n");
+			free(path);
+			return -1;
+		}
+
+		free(path);
+	}
+
+	return 0;
+}
 
 static void print_cmdline(const char *pid_str)
 {
@@ -460,7 +557,7 @@ static void format_current_time(char *buf, size_t buf_size)
 	struct tm tm_now;
 
 	now = time(NULL);
-	if (localtime_r(&now, &tm_now) == NULL) {
+	if (!localtime_r(&now, &tm_now)) {
 		snprintf(buf, buf_size, "00/00/00 00:00:00");
 		return;
 	}
@@ -790,6 +887,11 @@ static void run_live_mode(void)
 int main(int argc, char **argv)
 {
 	init_color_output();
+	print_logo_text();
+	if (ensure_module_loaded() < 0)
+		return -1;
+	if (ensure_proc_files_present() < 0)
+		return -1;
 
 	if (argc > 1) {
 		char pid_user[20];

--- a/src/proc_elf_ctrl_tests.c
+++ b/src/proc_elf_ctrl_tests.c
@@ -23,6 +23,10 @@ static int fail_pid_open;
 static int fail_det_open;
 static int fail_threads_open;
 static int fail_cmdline_open;
+static int module_loaded;
+static int proc_pid_present;
+static int proc_det_present;
+static int proc_threads_present;
 
 static void append_output(const char *fmt, ...)
 {
@@ -64,6 +68,10 @@ static void reset_mocks(void)
 	fail_det_open = 0;
 	fail_threads_open = 0;
 	fail_cmdline_open = 0;
+	module_loaded = 1;
+	proc_pid_present = 1;
+	proc_det_present = 1;
+	proc_threads_present = 1;
 
 	memset(cmdline_content, 0, sizeof(cmdline_content));
 	cmdline_len = 0;
@@ -102,7 +110,31 @@ static FILE *mock_fopen(const char *path, const char *mode)
 		return fmemopen((void *)cmdline_content, cmdline_len, "r");
 	}
 
+	if (!strcmp(path, "/proc/modules") && strchr(mode, 'r')) {
+		if (module_loaded)
+			return fmemopen((void *)"elf_det 0 0 - Live 0x0\n", 23,
+					"r");
+
+		return fmemopen((void *)"", 0, "r");
+	}
+
 	return NULL;
+}
+
+static int mock_access(const char *path, int mode)
+{
+	(void)mode;
+
+	if (!strcmp(path, "/fake_proc/pid"))
+		return proc_pid_present ? 0 : -1;
+
+	if (!strcmp(path, "/fake_proc/det"))
+		return proc_det_present ? 0 : -1;
+
+	if (!strcmp(path, "/fake_proc/threads"))
+		return proc_threads_present ? 0 : -1;
+
+	return -1;
 }
 
 static int mock_printf(const char *fmt, ...)
@@ -131,6 +163,7 @@ static void mock_perror(const char *s)
 }
 
 #define fopen  mock_fopen
+#define access mock_access
 #define printf mock_printf
 #define puts   mock_puts
 #define perror mock_perror
@@ -140,6 +173,7 @@ static void mock_perror(const char *s)
 #undef perror
 #undef puts
 #undef printf
+#undef access
 #undef fopen
 
 static void test_build_proc_path_helper(void)
@@ -197,7 +231,7 @@ static void test_print_process_info_happy_path(void)
 
 	print_process_info("1234");
 
-	assert(pid_stream_buf != NULL);
+	assert(pid_stream_buf);
 	assert(strcmp(pid_stream_buf, "1234") == 0);
 	assert(strstr(output_buf, "PROCESS INFORMATION"));
 	assert(strstr(output_buf, "THREAD INFORMATION"));
@@ -207,16 +241,46 @@ static void test_print_process_info_happy_path(void)
 
 static void test_main_argument_pid_is_bounded(void)
 {
-	char long_pid[] = "123456789012345678901234567890";
-	char *argv[] = {"prog", long_pid};
+	static const char *const argv[] = {
+		"prog",
+		"123456789012345678901234567890",
+	};
+	int rc;
 
 	reset_mocks();
 	cmdline_len = 0;
-	proc_elf_ctrl_entry(2, argv);
+	rc = proc_elf_ctrl_entry(2, (char **)argv);
 
-	assert(pid_stream_buf != NULL);
+	assert(rc == 0);
+	assert(pid_stream_buf);
 	assert(pid_stream_len == 19);
 	assert(strncmp(pid_stream_buf, "1234567890123456789", 19) == 0);
+}
+
+static void test_main_exits_when_module_not_loaded(void)
+{
+	static const char *const argv[] = {"prog", "1"};
+	int rc;
+
+	reset_mocks();
+	module_loaded = 0;
+	rc = proc_elf_ctrl_entry(2, (char **)argv);
+
+	assert(rc == -1);
+	assert(!pid_stream_buf);
+}
+
+static void test_main_exits_when_proc_file_missing(void)
+{
+	static const char *const argv[] = {"prog", "1"};
+	int rc;
+
+	reset_mocks();
+	proc_threads_present = 0;
+	rc = proc_elf_ctrl_entry(2, (char **)argv);
+
+	assert(rc == -1);
+	assert(!pid_stream_buf);
 }
 
 static void test_det_preamble_stops_before_sections(void)
@@ -308,8 +372,9 @@ static void test_live_header_and_footer_show_timestamps(void)
 
 	reset_mocks();
 	memset(&snap, 0, sizeof(snap));
-	strcpy(snap.pid, "123");
-	strcpy(snap.captured_at, "26/03/26 12:34:56");
+	snprintf(snap.pid, sizeof(snap.pid), "%s", "123");
+	snprintf(snap.captured_at, sizeof(snap.captured_at), "%s",
+		 "26/03/26 12:34:56");
 	snap.view = VIEW_MEMORY;
 	print_live_header(&snap, 0, 1);
 	print_live_footer(snap.captured_at);
@@ -329,23 +394,25 @@ static void test_snapshot_history_offset_navigation(void)
 	memset(history, 0, sizeof(history));
 	memset(&snap, 0, sizeof(snap));
 
-	strcpy(snap.pid, "111");
-	strcpy(snap.captured_at, "26/03/26 12:00:01");
+	snprintf(snap.pid, sizeof(snap.pid), "%s", "111");
+	snprintf(snap.captured_at, sizeof(snap.captured_at), "%s",
+		 "26/03/26 12:00:01");
 	snap.view = VIEW_MEMORY;
 	append_snapshot(history, &history_count, &history_next, &snap);
 
-	strcpy(snap.pid, "222");
-	strcpy(snap.captured_at, "26/03/26 12:00:02");
+	snprintf(snap.pid, sizeof(snap.pid), "%s", "222");
+	snprintf(snap.captured_at, sizeof(snap.captured_at), "%s",
+		 "26/03/26 12:00:02");
 	append_snapshot(history, &history_count, &history_next, &snap);
 
 	picked =
 		get_snapshot_by_offset(history, history_count, history_next, 0);
-	assert(picked != NULL);
+	assert(picked);
 	assert(strcmp(picked->pid, "222") == 0);
 
 	picked =
 		get_snapshot_by_offset(history, history_count, history_next, 1);
-	assert(picked != NULL);
+	assert(picked);
 	assert(strcmp(picked->pid, "111") == 0);
 
 	clear_snapshot_history(history, &history_count, &history_next);
@@ -357,6 +424,8 @@ int main(void)
 	test_print_cmdline_replaces_nul_with_space();
 	test_print_process_info_happy_path();
 	test_main_argument_pid_is_bounded();
+	test_main_exits_when_module_not_loaded();
+	test_main_exits_when_proc_file_missing();
 	test_det_preamble_stops_before_sections();
 	test_memory_view_filters_network_section();
 	test_network_view_starts_from_network_section();


### PR DESCRIPTION
This pull request introduces robust startup validation for the live mode in `proc_elf_ctrl`, ensuring the required kernel module and proc files are present before proceeding. It adds a startup logo, improves error reporting, and updates the test suite with mocks and new test cases for these behaviors.

**Startup validation and error handling:**
- Added `print_logo_text`, `ensure_module_loaded`, and `ensure_proc_files_present` functions to `proc_elf_ctrl.c` to display a logo and check for the presence of the `elf_det` kernel module and required proc files (`pid`, `det`, `threads`). The program now exits immediately with an error if any are missing, with user-friendly error messages and hints.

**Testing improvements:**
- Enhanced the test suite in `proc_elf_ctrl_tests.c` to mock module and proc file presence, including new test cases to verify that the main function exits early if the module is not loaded or if required proc files are missing.
- Updated test mocks and assertions for improved reliability and coverage, including stricter buffer checks and improved string handling in tests.

**Documentation:**
- Updated `docs/TESTING.md` to document the new startup validation behavior, including the logo display and immediate exit conditions for missing dependencies.

**Minor code quality improvements:**
- Added the `ARRAY_SIZE` macro for safer array handling and improved error handling in time formatting.