### PR TITLE
the units are now auto for i/o

### DIFF
--- a/src/proclens_module.c
+++ b/src/proclens_module.c
@@ -281,6 +281,14 @@ static void print_io_stats(struct seq_file *m, struct task_struct *task)
 	u64 avg_read_bytes;
 	u64 avg_write_bytes;
 	u64 io_intensity;
+	char rchar_str[32];
+	char wchar_str[32];
+	char read_bytes_str[32];
+	char write_bytes_str[32];
+	char cancelled_write_bytes_str[32];
+	char avg_read_bytes_str[32];
+	char avg_write_bytes_str[32];
+	char io_intensity_str[32];
 
 	seq_puts(m, "\n[io]\n");
 
@@ -297,16 +305,29 @@ static void print_io_stats(struct seq_file *m, struct task_struct *task)
 	avg_write_bytes = calculate_avg_bytes_per_syscall(wchar, syscw);
 	io_intensity = calculate_io_intensity(read_bytes, write_bytes);
 
-	seq_printf(m, "rchar: %llu\n", rchar);
-	seq_printf(m, "wchar: %llu\n", wchar);
+	format_size_with_unit((unsigned long)rchar, rchar_str, sizeof(rchar_str));
+	format_size_with_unit((unsigned long)wchar, wchar_str, sizeof(wchar_str));
+	format_size_with_unit((unsigned long)read_bytes, read_bytes_str, sizeof(read_bytes_str));
+	format_size_with_unit((unsigned long)write_bytes, write_bytes_str, sizeof(write_bytes_str));
+	format_size_with_unit((unsigned long)cancelled_write_bytes, cancelled_write_bytes_str,
+			      sizeof(cancelled_write_bytes_str));
+	format_size_with_unit((unsigned long)avg_read_bytes, avg_read_bytes_str,
+			      sizeof(avg_read_bytes_str));
+	format_size_with_unit((unsigned long)avg_write_bytes, avg_write_bytes_str,
+			      sizeof(avg_write_bytes_str));
+	format_size_with_unit((unsigned long)io_intensity, io_intensity_str,
+			      sizeof(io_intensity_str));
+
+	seq_printf(m, "rchar: %s\n", rchar_str);
+	seq_printf(m, "wchar: %s\n", wchar_str);
 	seq_printf(m, "syscr: %llu\n", syscr);
 	seq_printf(m, "syscw: %llu\n", syscw);
-	seq_printf(m, "read_bytes: %llu\n", read_bytes);
-	seq_printf(m, "write_bytes: %llu\n", write_bytes);
-	seq_printf(m, "cancelled_write_bytes: %llu\n", cancelled_write_bytes);
-	seq_printf(m, "avg_read_bytes_per_syscall: %llu\n", avg_read_bytes);
-	seq_printf(m, "avg_write_bytes_per_syscall: %llu\n", avg_write_bytes);
-	seq_printf(m, "io_intensity: %llu\n", io_intensity);
+	seq_printf(m, "read_bytes: %s\n", read_bytes_str);
+	seq_printf(m, "write_bytes: %s\n", write_bytes_str);
+	seq_printf(m, "cancelled_write_bytes: %s\n", cancelled_write_bytes_str);
+	seq_printf(m, "avg_read_bytes_per_syscall: %s\n", avg_read_bytes_str);
+	seq_printf(m, "avg_write_bytes_per_syscall: %s\n", avg_write_bytes_str);
+	seq_printf(m, "io_intensity: %s\n", io_intensity_str);
 #else
 	seq_puts(m, "status: unavailable (CONFIG_TASK_XACCT disabled)\n");
 #endif

--- a/src/proclens_module.h
+++ b/src/proclens_module.h
@@ -283,7 +283,7 @@ static inline void try_insert_top_talker(struct top_talker_entry *list,
 	list[insert_at] = entry;
 }
 
-/* Format size with appropriate unit (B, KB, MB)
+/* Format size with appropriate unit (B, KB, MB, GB)
  * Returns number of characters written (excluding null terminator)
  */
 static inline int format_size_with_unit(unsigned long size, char *out_buf, int buf_size)
@@ -291,8 +291,10 @@ static inline int format_size_with_unit(unsigned long size, char *out_buf, int b
 	if (!out_buf || buf_size < 10)
 		return 0;
 
-	if (size >= 1024 * 1024)
-		return snprintf(out_buf, buf_size, "%lu MB", size / (1024 * 1024));
+	if (size >= 1024UL * 1024UL * 1024UL)
+		return snprintf(out_buf, buf_size, "%lu GB", size / (1024UL * 1024UL * 1024UL));
+	else if (size >= 1024UL * 1024UL)
+		return snprintf(out_buf, buf_size, "%lu MB", size / (1024UL * 1024UL));
 	else if (size >= 1024)
 		return snprintf(out_buf, buf_size, "%lu KB", size / 1024);
 	else

--- a/src/proclens_module_tests.c
+++ b/src/proclens_module_tests.c
@@ -123,6 +123,14 @@ int main(void)
 	len = format_size_with_unit(5 * 1024 * 1024, size_buf, sizeof(size_buf));
 	assert(strcmp(size_buf, "5 MB") == 0);
 
+	/* Test gigabytes */
+	len = format_size_with_unit(1024UL * 1024UL * 1024UL, size_buf, sizeof(size_buf));
+	assert(strcmp(size_buf, "1 GB") == 0);
+	assert(len > 0);
+
+	len = format_size_with_unit(3UL * 1024UL * 1024UL * 1024UL, size_buf, sizeof(size_buf));
+	assert(strcmp(size_buf, "3 GB") == 0);
+
 	/* Test edge cases */
 	len = format_size_with_unit(0, size_buf, sizeof(size_buf));
 	assert(strcmp(size_buf, "0 B") == 0);

--- a/src/proclens_tests.c
+++ b/src/proclens_tests.c
@@ -379,7 +379,7 @@ static void test_io_view_starts_from_io_section(void)
 			  "sockets_total: 2\n"
 			  "[io]\n"
 			  "rchar: 123\n"
-			  "io_intensity: 456\n";
+			  "io_intensity: 456 B\n";
 
 	reset_mocks();
 	print_io_view(det);
@@ -388,7 +388,7 @@ static void test_io_view_starts_from_io_section(void)
 	assert(!strstr(output_buf, "[network]"));
 	assert(strstr(output_buf, "[io]"));
 	assert(strstr(output_buf, "rchar: 123"));
-	assert(strstr(output_buf, "io_intensity: 456"));
+	assert(strstr(output_buf, "io_intensity: 456 B"));
 }
 
 static void test_format_current_time_layout(void)


### PR DESCRIPTION
This pull request updates the way I/O statistics are displayed by formatting byte counts with human-readable units (B, KB, MB, GB) rather than raw numbers, and ensures the formatting is tested and reflected in the output. The changes improve clarity for users interpreting I/O data.

## Formatting improvements for I/O statistics

- Updated `print_io_stats` in `proclens_module.c` to use the `format_size_with_unit` helper for all byte-count fields, so values are shown as "KB", "MB", or "GB" where appropriate, instead of just raw numbers.
- Enhanced the `format_size_with_unit` function in `proclens_module.h` to support gigabyte ("GB") formatting in addition to bytes, kilobytes, and megabytes.

## Testing and output validation

- Added new test cases in `proclens_module_tests.c` to verify correct formatting for gigabyte values.
- Updated the expected output in `proclens_tests.c` to reflect the new unit-suffixed formatting, specifically for the `io_intensity` field.